### PR TITLE
Fix tkinter, ensurepip, and broken-venv setup failures

### DIFF
--- a/TomoTexture.command
+++ b/TomoTexture.command
@@ -3,12 +3,13 @@
 # Double-click this file (or run from Terminal) to launch TomoTexture.
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
-if [ ! -x "$DIR/.venv/bin/python" ]; then
-    echo "TomoTexture: missing $DIR/.venv/bin/python — did setup run?" >&2
-    exit 1
-fi
-if [ ! -f "$DIR/app_runtime/__main__.pyc" ]; then
-    echo "TomoTexture: missing $DIR/app_runtime/__main__.pyc — bundle is incomplete." >&2
+if [ ! -x "$DIR/.venv/bin/python" ] || [ ! -f "$DIR/app_runtime/__main__.pyc" ]; then
+    echo "TomoTexture: install is incomplete — setup didn't finish successfully." >&2
+    echo "Re-run setup with:" >&2
+    echo "    cd \"$DIR\" && ./setup.sh" >&2
+    echo "If that still fails, open an issue at" >&2
+    echo "    https://github.com/zachmtz08/tomotexture-port/issues" >&2
+    echo "and paste the full output of setup.sh." >&2
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ It may need to install the following on your Mac (skipped if already present):
   1. Xcode Command Line Tools  (Apple, required for git)
   2. Homebrew                  (package manager)
   3. Python 3.14               (required by the app)
+  4. python-tk@3.14            (Tk bindings; the app's UI needs them)
 
 You may be prompted for your password or to click Install in a dialog.
 Press Enter to continue, or close this window to cancel.
@@ -94,6 +95,20 @@ if ! command -v python3.14 >/dev/null 2>&1; then
     ok "Python 3.14 installed"
 else
     ok "Python 3.14 already installed"
+fi
+
+# --- Step 3b: Tk bindings for Python 3.14 -----------------------------------
+# Homebrew's python@3.14 does NOT bundle _tkinter; the app's UI imports it and
+# crashes on launch with "ModuleNotFoundError: No module named '_tkinter'"
+# unless python-tk@3.14 is installed alongside it.
+
+if ! python3.14 -c "import _tkinter" >/dev/null 2>&1; then
+    banner "Installing Tk bindings (python-tk@3.14)"
+    brew install python-tk@3.14
+    python3.14 -c "import _tkinter" >/dev/null 2>&1 || die "python-tk@3.14 installed but Python still can't import _tkinter. Try: brew reinstall python-tk@3.14"
+    ok "Tk bindings installed"
+else
+    ok "Tk bindings already available"
 fi
 
 # --- Step 4: Clone / pull the repo ------------------------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -19,9 +19,29 @@ if ! command -v python3.14 >/dev/null 2>&1; then
     exit 1
 fi
 
+# A pre-existing .venv missing its python binary is broken (e.g. previous
+# setup run aborted mid-creation). Wipe it so we recreate from scratch.
+if [ -d ".venv" ] && [ ! -x ".venv/bin/python" ]; then
+    echo "Removing incomplete .venv..."
+    rm -rf .venv
+fi
+
 if [ ! -d ".venv" ]; then
     echo "Creating .venv with Python 3.14..."
-    python3.14 -m venv .venv
+    # Some Homebrew python@3.14 builds ship a broken ensurepip; fall back to
+    # creating the venv without pip and bootstrapping via get-pip.py.
+    if ! python3.14 -m venv .venv 2>/tmp/tomotexture-venv.err; then
+        echo "Standard venv creation failed; retrying without pip..."
+        rm -rf .venv
+        python3.14 -m venv --without-pip .venv
+    fi
+fi
+
+if [ ! -x ".venv/bin/pip" ]; then
+    echo "Bootstrapping pip via get-pip.py..."
+    curl -fsSL https://bootstrap.pypa.io/get-pip.py -o /tmp/tomotexture-get-pip.py
+    .venv/bin/python /tmp/tomotexture-get-pip.py --quiet
+    rm -f /tmp/tomotexture-get-pip.py
 fi
 
 echo "Installing dependencies into .venv..."


### PR DESCRIPTION
## Summary
- Install `python-tk@3.14` so the app's Tk-based UI can launch (#1)
- Detect a broken `.venv` (no python binary) and recreate it; fall back to `--without-pip` + `get-pip.py` when `ensurepip` fails on Homebrew python@3.14 (#2, #6)
- Replace the cryptic "missing `__main__.pyc`" error with actionable re-run-setup guidance (#7)

## Test plan
- [ ] Fresh macOS box: one-liner installer completes without errors
- [ ] App launches (UI shows) — no `ModuleNotFoundError: _tkinter`
- [ ] On a machine where `ensurepip` fails, `setup.sh` recovers via get-pip.py fallback
- [ ] With a manually-broken `.venv` (delete `.venv/bin/python`), re-running `setup.sh` recreates it cleanly
- [ ] Launching with no `app_runtime/__main__.pyc` prints the new error pointing at `./setup.sh`

Closes #1, #2, #6, #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)